### PR TITLE
FEATURE: add MPTCP per address support

### DIFF
--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -28255,6 +28255,27 @@ report this to the maintainers.
                                  range can or must be specified.
                                  It is considered as an alias of 'stream+ipv4@'.
 
+'mptcp@<address>[:port1[-port2]]' following <address> is considered as an IPv4
+                                  or IPv6 address depending of the syntax but
+                                  socket type and transport method is forced to
+                                  "stream", with the MPTCP protocol. Depending
+                                  on the statement using this address, a port or
+                                  a port range can or must be specified.
+
+'mptcp4@<address>[:port1[-port2]]' following <address> is always considered as
+                                   an IPv4 address but socket type and transport
+                                   method is forced to "stream", with the MPTCP
+                                   protocol. Depending on the statement using
+                                   this address, a port or port range can or
+                                   must be specified.
+
+'mptcp6@<address>[:port1[-port2]]' following <address> is always considered as
+                                   an IPv6 address but socket type and transport
+                                   method is forced to "stream", with the MPTCP
+                                   protocol. Depending on the statement using
+                                   this address, a port or port range can or
+                                   must be specified.
+
 'udp@<address>[:port1[-port2]]' following <address> is considered as an IPv4
                                 or IPv6 address depending of the syntax but
                                 socket type and transport method is forced to

--- a/examples/mptcp-backend.py
+++ b/examples/mptcp-backend.py
@@ -1,0 +1,22 @@
+# =============================================================================
+# Example of a simple backend server using mptcp in python, used with mptcp.cfg
+# =============================================================================
+
+import socket
+
+sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM, socket.IPPROTO_MPTCP)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+# dual stack IPv4/IPv6
+sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+
+sock.bind(("::", 4331))
+sock.listen()
+
+while True:
+    (conn, address) = sock.accept()
+    req = conn.recv(1024)
+    print(F"Received request : {req}")
+    conn.send(b"HTTP/1.0 200 OK\r\n\r\nHello\n")
+    conn.close()
+
+sock.close()

--- a/examples/mptcp.cfg
+++ b/examples/mptcp.cfg
@@ -1,0 +1,23 @@
+# You can test this configuration by running the command:
+#
+#   $ mptcpize run curl localhost:5000
+
+global
+   strict-limits  # refuse to start if insufficient FDs/memory
+   # add some process-wide tuning here if required
+
+defaults
+   mode http
+   balance roundrobin
+   timeout client 60s
+   timeout server 60s
+   timeout connect 1s
+
+frontend main
+    bind mptcp@[::]:5000
+    default_backend mptcp_backend
+
+# MPTCP is usually used on the frontend, but it is also possible
+# to enable it to communicate with the backend
+backend mptcp_backend
+    server mptcp_server mptcp@[::]:4331

--- a/include/haproxy/compat.h
+++ b/include/haproxy/compat.h
@@ -317,6 +317,16 @@ typedef struct { } empty_t;
 #define queue _queue
 #endif
 
+/* Define a flag indicating if MPTCP is available */
+#ifdef __linux__
+#define HA_HAVE_MPTCP 1
+#endif
+
+/* only Linux defines IPPROTO_MPTCP */
+#ifndef IPPROTO_MPTCP
+#define IPPROTO_MPTCP 262
+#endif
+
 #endif /* _HAPROXY_COMPAT_H */
 
 /*

--- a/include/haproxy/protocol.h
+++ b/include/haproxy/protocol.h
@@ -95,10 +95,10 @@ int protocol_enable_all(void);
  * supported protocol types, and ctrl_type of either SOCK_STREAM or SOCK_DGRAM
  * depending on the requested values, or NULL if not found.
  */
-static inline struct protocol *protocol_lookup(int family, enum proto_type proto_type, int ctrl_dgram)
+static inline struct protocol *protocol_lookup(int family, enum proto_type proto_type, int alt)
 {
 	if (family >= 0 && family < AF_CUST_MAX)
-		return __protocol_by_family[family][proto_type][!!ctrl_dgram];
+		return __protocol_by_family[family][proto_type][!!alt];
 	return NULL;
 }
 

--- a/include/haproxy/server-t.h
+++ b/include/haproxy/server-t.h
@@ -381,6 +381,7 @@ struct server {
 
 	const struct netns_entry *netns;        /* contains network namespace name or NULL. Network namespace comes from configuration */
 	struct xprt_ops *xprt;                  /* transport-layer operations */
+	int alt_proto;                          /* alternate protocol to use in protocol_lookup */
 	unsigned int svc_port;                  /* the port to connect to (for relevant families) */
 	unsigned down_time;			/* total time the server was down */
 

--- a/include/haproxy/sock_inet.h
+++ b/include/haproxy/sock_inet.h
@@ -31,6 +31,14 @@ extern int sock_inet6_v6only_default;
 extern int sock_inet_tcp_maxseg_default;
 extern int sock_inet6_tcp_maxseg_default;
 
+#ifdef HA_HAVE_MPTCP
+extern int sock_inet_mptcp_maxseg_default;
+extern int sock_inet6_mptcp_maxseg_default;
+#else 
+#define sock_inet_mptcp_maxseg_default -1
+#define sock_inet6_mptcp_maxseg_default -1
+#endif
+
 extern struct proto_fam proto_fam_inet4;
 extern struct proto_fam proto_fam_inet6;
 

--- a/include/haproxy/tools.h
+++ b/include/haproxy/tools.h
@@ -286,7 +286,7 @@ static inline int is_idchar(char c)
  */
 struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int *high, int *fd,
                                       struct protocol **proto, struct net_addr_type *sa_type,
-                                      char **err, const char *pfx, char **fqdn, unsigned int opts);
+                                      char **err, const char *pfx, char **fqdn, int *alt, unsigned int opts);
 
 
 /* converts <addr> and <port> into a string representation of the address and port. This is sort

--- a/src/backend.c
+++ b/src/backend.c
@@ -1690,8 +1690,9 @@ skip_reuse:
 
 	if (!srv_conn->xprt) {
 		/* set the correct protocol on the output stream connector */
+
 		if (srv) {
-			if (conn_prepare(srv_conn, protocol_lookup(srv_conn->dst->ss_family, PROTO_TYPE_STREAM, 0), srv->xprt)) {
+			if (conn_prepare(srv_conn, protocol_lookup(srv_conn->dst->ss_family, PROTO_TYPE_STREAM, srv->alt_proto), srv->xprt)) {
 				conn_free(srv_conn);
 				return SF_ERR_INTERNAL;
 			}

--- a/src/cfgparse-listen.c
+++ b/src/cfgparse-listen.c
@@ -2497,7 +2497,7 @@ stats_error_parsing:
 			err_code |= ERR_WARN;
 
 		sk = str2sa_range(args[1], NULL, &port1, &port2, NULL, NULL, NULL,
-		                  &errmsg, NULL, NULL,
+		                  &errmsg, NULL, NULL, NULL,
 		                  PA_O_RESOLVE | PA_O_PORT_OK | PA_O_PORT_MAND | PA_O_STREAM | PA_O_XPRT | PA_O_CONNECT);
 		if (!sk) {
 			ha_alert("parsing [%s:%d] : '%s' : %s\n", file, linenum, args[0], errmsg);
@@ -2786,7 +2786,8 @@ stats_error_parsing:
 		curproxy->conn_src.iface_len = 0;
 
 		sk = str2sa_range(args[1], NULL, &port1, &port2, NULL, NULL, NULL,
-		                  &errmsg, NULL, NULL, PA_O_RESOLVE | PA_O_PORT_OK | PA_O_STREAM | PA_O_CONNECT);
+		                  &errmsg, NULL, NULL, NULL,
+		                  PA_O_RESOLVE | PA_O_PORT_OK | PA_O_STREAM | PA_O_CONNECT);
 		if (!sk) {
 			ha_alert("parsing [%s:%d] : '%s %s' : %s\n",
 				 file, linenum, args[0], args[1], errmsg);
@@ -2860,7 +2861,8 @@ stats_error_parsing:
 					struct sockaddr_storage *sk;
 
 					sk = str2sa_range(args[cur_arg + 1], NULL, &port1, &port2, NULL, NULL, NULL,
-					                  &errmsg, NULL, NULL, PA_O_RESOLVE | PA_O_PORT_OK | PA_O_STREAM | PA_O_CONNECT);
+					                  &errmsg, NULL, NULL, NULL,
+					                  PA_O_RESOLVE | PA_O_PORT_OK | PA_O_STREAM | PA_O_CONNECT);
 					if (!sk) {
 						ha_alert("parsing [%s:%d] : '%s %s' : %s\n",
 							 file, linenum, args[cur_arg], args[cur_arg+1], errmsg);

--- a/src/cfgparse.c
+++ b/src/cfgparse.c
@@ -158,7 +158,7 @@ int str2listener(char *str, struct proxy *curproxy, struct bind_conf *bind_conf,
 
 		ss2 = str2sa_range(str, NULL, &port, &end, &fd, &proto, NULL, err,
 		                   (curproxy == global.cli_fe || curproxy == mworker_proxy) ? NULL : global.unix_bind.prefix,
-		                   NULL, PA_O_RESOLVE | PA_O_PORT_OK | PA_O_PORT_MAND | PA_O_PORT_RANGE |
+		                   NULL, NULL, PA_O_RESOLVE | PA_O_PORT_OK | PA_O_PORT_MAND | PA_O_PORT_RANGE |
 		                          PA_O_SOCKET_FD | PA_O_STREAM | PA_O_XPRT);
 		if (!ss2)
 			goto fail;
@@ -244,7 +244,7 @@ int str2receiver(char *str, struct proxy *curproxy, struct bind_conf *bind_conf,
 
 		ss2 = str2sa_range(str, NULL, &port, &end, &fd, &proto, NULL, err,
 		                   curproxy == global.cli_fe ? NULL : global.unix_bind.prefix,
-		                   NULL, PA_O_RESOLVE | PA_O_PORT_OK | PA_O_PORT_MAND | PA_O_PORT_RANGE |
+		                   NULL, NULL, PA_O_RESOLVE | PA_O_PORT_OK | PA_O_PORT_MAND | PA_O_PORT_RANGE |
 		                          PA_O_SOCKET_FD | PA_O_DGRAM | PA_O_XPRT);
 		if (!ss2)
 			goto fail;
@@ -1185,7 +1185,7 @@ int cfg_parse_mailers(const char *file, int linenum, char **args, int kwm)
 		newmailer->id = strdup(args[1]);
 
 		sk = str2sa_range(args[2], NULL, &port1, &port2, NULL, &proto, NULL,
-		                  &errmsg, NULL, NULL,
+		                  &errmsg, NULL, NULL, NULL,
 		                  PA_O_RESOLVE | PA_O_PORT_OK | PA_O_PORT_MAND | PA_O_STREAM | PA_O_XPRT | PA_O_CONNECT);
 		if (!sk) {
 			ha_alert("parsing [%s:%d] : '%s %s' : %s\n", file, linenum, args[0], args[1], errmsg);

--- a/src/check.c
+++ b/src/check.c
@@ -2032,7 +2032,7 @@ static int srv_parse_addr(char **args, int *cur_arg, struct proxy *curpx, struct
 		goto error;
 	}
 
-	sk = str2sa_range(args[*cur_arg+1], NULL, &port1, &port2, NULL, NULL, NULL, errmsg, NULL, NULL,
+	sk = str2sa_range(args[*cur_arg+1], NULL, &port1, &port2, NULL, NULL, NULL, errmsg, NULL, NULL, NULL,
 	                  PA_O_RESOLVE | PA_O_PORT_OK | PA_O_STREAM | PA_O_CONNECT);
 	if (!sk) {
 		memprintf(errmsg, "'%s' : %s", args[*cur_arg], *errmsg);

--- a/src/cli.c
+++ b/src/cli.c
@@ -3335,7 +3335,7 @@ int mworker_cli_proxy_create()
 
 		memprintf(&msg, "sockpair@%d", child->ipc_fd[0]);
 		if ((sk = str2sa_range(msg, &port, &port1, &port2, NULL, &proto, NULL,
-		                       &errmsg, NULL, NULL, PA_O_STREAM)) == 0) {
+		                       &errmsg, NULL, NULL, NULL, PA_O_STREAM)) == 0) {
 			goto error;
 		}
 		ha_free(&msg);

--- a/src/hlua.c
+++ b/src/hlua.c
@@ -3519,7 +3519,8 @@ __LJMP static int hlua_socket_connect(struct lua_State *L)
 		csk_ctx->srv = socket_tcp;
 
 	/* Parse ip address. */
-	addr = str2sa_range(ip, NULL, &low, &high, NULL, NULL, NULL, NULL, NULL, NULL, PA_O_PORT_OK | PA_O_STREAM);
+	addr = str2sa_range(ip, NULL, &low, &high, NULL, NULL, NULL, NULL,
+	                    NULL, NULL, NULL, PA_O_PORT_OK | PA_O_STREAM);
 	if (!addr) {
 		xref_unlock(&socket->xref, peer);
 		WILL_LJMP(luaL_error(L, "connect: cannot parse destination address '%s'", ip));

--- a/src/http_client.c
+++ b/src/http_client.c
@@ -455,7 +455,7 @@ int httpclient_set_dst(struct httpclient *hc, const char *dst)
 	sockaddr_free(&hc->dst);
 	/* 'sk' is statically allocated (no need to be freed). */
 	sk = str2sa_range(dst, NULL, NULL, NULL, NULL, NULL, NULL,
-	                  &errmsg, NULL, NULL,
+	                  &errmsg, NULL, NULL, NULL,
 	                  PA_O_PORT_OK | PA_O_STREAM | PA_O_XPRT | PA_O_CONNECT);
 	if (!sk) {
 		ha_alert("httpclient: Failed to parse destination address in %s\n", errmsg);

--- a/src/log.c
+++ b/src/log.c
@@ -1600,7 +1600,7 @@ static int parse_log_target(char *raw, struct log_target *target, char **err)
 
 	/* parse the target address */
 	sk = str2sa_range(raw, NULL, &port1, &port2, &fd, &proto, NULL,
-	                  err, NULL, NULL,
+	                  err, NULL, NULL, NULL,
 	                  PA_O_RESOLVE | PA_O_PORT_OK | PA_O_RAW_FD | PA_O_DGRAM | PA_O_STREAM | PA_O_DEFAULT_DGRAM);
 	if (!sk)
 		goto error;

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -51,7 +51,8 @@ void protocol_register(struct protocol *proto)
 	LIST_APPEND(&protocols, &proto->list);
 	__protocol_by_family[sock_family]
 	                    [proto->proto_type]
-	                    [proto->xprt_type == PROTO_TYPE_DGRAM] = proto;
+	                    [proto->xprt_type == PROTO_TYPE_DGRAM ||
+	                     proto->sock_prot == IPPROTO_MPTCP] = proto;
 	__proto_fam_by_family[sock_family] = proto->fam;
 	HA_SPIN_UNLOCK(PROTO_LOCK, &proto_lock);
 }

--- a/src/resolvers.c
+++ b/src/resolvers.c
@@ -3616,7 +3616,8 @@ int cfg_parse_resolvers(const char *file, int linenum, char **args, int kwm)
 		}
 
 		sk = str2sa_range(args[2], NULL, &port1, &port2, NULL, &proto, NULL,
-		                  &errmsg, NULL, NULL, PA_O_RESOLVE | PA_O_PORT_OK | PA_O_PORT_MAND | PA_O_DGRAM | PA_O_STREAM | PA_O_DEFAULT_DGRAM);
+		                  &errmsg, NULL, NULL, NULL,
+		                  PA_O_RESOLVE | PA_O_PORT_OK | PA_O_PORT_MAND | PA_O_DGRAM | PA_O_STREAM | PA_O_DEFAULT_DGRAM);
 		if (!sk) {
 			ha_alert("parsing [%s:%d] : '%s %s' : %s\n", file, linenum, args[0], args[1], errmsg);
 			err_code |= ERR_ALERT | ERR_FATAL;

--- a/src/server.c
+++ b/src/server.c
@@ -3306,6 +3306,7 @@ static int _srv_parse_init(struct server **srv, char **args, int *cur_arg,
 	const char *err = NULL;
 	int err_code = 0;
 	char *fqdn = NULL;
+	int alt_proto = 0;
 	int tmpl_range_low = 0, tmpl_range_high = 0;
 	char *errmsg = NULL;
 
@@ -3396,7 +3397,7 @@ static int _srv_parse_init(struct server **srv, char **args, int *cur_arg,
 			goto skip_addr;
 
 		sk = str2sa_range(args[*cur_arg], &port, &port1, &port2, NULL, NULL, &newsrv->addr_type,
-		                  &errmsg, NULL, &fqdn, NULL,
+		                  &errmsg, NULL, &fqdn, &alt_proto,
 		                  (parse_flags & SRV_PARSE_INITIAL_RESOLVE ? PA_O_RESOLVE : 0) | PA_O_PORT_OK |
 				  (parse_flags & SRV_PARSE_IN_PEER_SECTION ? PA_O_PORT_MAND : PA_O_PORT_OFS) |
 				  PA_O_STREAM | PA_O_DGRAM | PA_O_XPRT);
@@ -3439,6 +3440,7 @@ static int _srv_parse_init(struct server **srv, char **args, int *cur_arg,
 
 		newsrv->addr = *sk;
 		newsrv->svc_port = port;
+		newsrv->alt_proto = alt_proto;
 		/*
 		 * we don't need to lock the server here, because
 		 * we are in the process of initializing.

--- a/src/server.c
+++ b/src/server.c
@@ -1749,7 +1749,7 @@ static int srv_parse_source(char **args, int *cur_arg,
 
 	/* 'sk' is statically allocated (no need to be freed). */
 	sk = str2sa_range(args[*cur_arg + 1], NULL, &port_low, &port_high, NULL, NULL, NULL,
-	                  &errmsg, NULL, NULL,
+	                  &errmsg, NULL, NULL, NULL,
 		          PA_O_RESOLVE | PA_O_PORT_OK | PA_O_PORT_RANGE | PA_O_STREAM | PA_O_CONNECT);
 	if (!sk) {
 		memprintf(err, "'%s %s' : %s\n", args[*cur_arg], args[*cur_arg + 1], errmsg);
@@ -1837,7 +1837,7 @@ static int srv_parse_source(char **args, int *cur_arg,
 
 				/* 'sk' is statically allocated (no need to be freed). */
 				sk = str2sa_range(args[*cur_arg + 1], NULL, &port1, &port2, NULL, NULL, NULL,
-				                  &errmsg, NULL, NULL,
+				                  &errmsg, NULL, NULL, NULL,
 				                  PA_O_RESOLVE | PA_O_PORT_OK | PA_O_STREAM | PA_O_CONNECT);
 				if (!sk) {
 					ha_alert("'%s %s' : %s\n", args[*cur_arg], args[*cur_arg + 1], errmsg);
@@ -1927,7 +1927,7 @@ static int srv_parse_socks4(char **args, int *cur_arg,
 
 	/* 'sk' is statically allocated (no need to be freed). */
 	sk = str2sa_range(args[*cur_arg + 1], NULL, &port_low, &port_high, NULL, NULL, NULL,
-	                  &errmsg, NULL, NULL,
+	                  &errmsg, NULL, NULL, NULL,
 	                  PA_O_RESOLVE | PA_O_PORT_OK | PA_O_PORT_MAND | PA_O_STREAM | PA_O_CONNECT);
 	if (!sk) {
 		memprintf(err, "'%s %s' : %s\n", args[*cur_arg], args[*cur_arg + 1], errmsg);
@@ -3396,7 +3396,7 @@ static int _srv_parse_init(struct server **srv, char **args, int *cur_arg,
 			goto skip_addr;
 
 		sk = str2sa_range(args[*cur_arg], &port, &port1, &port2, NULL, NULL, &newsrv->addr_type,
-		                  &errmsg, NULL, &fqdn,
+		                  &errmsg, NULL, &fqdn, NULL,
 		                  (parse_flags & SRV_PARSE_INITIAL_RESOLVE ? PA_O_RESOLVE : 0) | PA_O_PORT_OK |
 				  (parse_flags & SRV_PARSE_IN_PEER_SECTION ? PA_O_PORT_MAND : PA_O_PORT_OFS) |
 				  PA_O_STREAM | PA_O_DGRAM | PA_O_XPRT);

--- a/src/sock.c
+++ b/src/sock.c
@@ -281,7 +281,7 @@ int sock_create_server_socket(struct connection *conn, struct proxy *be, int *st
 #endif
 	proto = protocol_lookup(conn->dst->ss_family, PROTO_TYPE_STREAM, 0);
 	BUG_ON(!proto);
-	sock_fd = my_socketat(ns, proto->fam->sock_domain, SOCK_STREAM, 0);
+	sock_fd = my_socketat(ns, proto->fam->sock_domain, SOCK_STREAM, proto->sock_prot);
 
 	/* at first, handle common to all proto families system limits and permission related errors */
 	if (sock_fd == -1) {

--- a/src/ssl_ocsp.c
+++ b/src/ssl_ocsp.c
@@ -1970,7 +1970,7 @@ static int ocsp_update_parse_global_http_proxy(char **args, int section_type, st
 	sockaddr_free(&ocsp_update_dst);
 	/* 'sk' is statically allocated (no need to be freed). */
 	sk = str2sa_range(args[1], NULL, NULL, NULL, NULL, NULL, NULL,
-	                  &errmsg, NULL, NULL,
+	                  &errmsg, NULL, NULL, NULL,
 	                  PA_O_PORT_OK | PA_O_STREAM | PA_O_XPRT | PA_O_CONNECT);
 	if (!sk) {
 		ha_alert("ocsp-update: Failed to parse destination address in %s\n", errmsg);

--- a/src/tcpcheck.c
+++ b/src/tcpcheck.c
@@ -2558,7 +2558,8 @@ struct tcpcheck_rule *parse_tcpcheck_connect(char **args, int cur_arg, struct pr
 			}
 
 			sk = str2sa_range(args[cur_arg+1], NULL, &port1, &port2, NULL, NULL, NULL,
-			                  errmsg, NULL, NULL, PA_O_RESOLVE | PA_O_PORT_OK | PA_O_STREAM | PA_O_CONNECT);
+			                  errmsg, NULL, NULL, NULL,
+			                  PA_O_RESOLVE | PA_O_PORT_OK | PA_O_STREAM | PA_O_CONNECT);
 			if (!sk) {
 				memprintf(errmsg, "'%s' : %s.", args[cur_arg], *errmsg);
 				goto error;

--- a/src/tools.c
+++ b/src/tools.c
@@ -1069,6 +1069,13 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 		proto_type = PROTO_TYPE_STREAM;
 		ctrl_type = SOCK_STREAM;
 	}
+	else if (strncmp(str2, "mptcp4@", 7) == 0) {
+		str2 += 7;
+		ss.ss_family = AF_INET;
+		proto_type = PROTO_TYPE_STREAM;
+		ctrl_type = SOCK_STREAM;
+		alt_proto = 1;
+	}
 	else if (strncmp(str2, "udp4@", 5) == 0) {
 		str2 += 5;
 		ss.ss_family = AF_INET;
@@ -1082,6 +1089,13 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 		proto_type = PROTO_TYPE_STREAM;
 		ctrl_type = SOCK_STREAM;
 	}
+	else if (strncmp(str2, "mptcp6@", 7) == 0) {
+		str2 += 7;
+		ss.ss_family = AF_INET6;
+		proto_type = PROTO_TYPE_STREAM;
+		ctrl_type = SOCK_STREAM;
+		alt_proto = 1;
+	}
 	else if (strncmp(str2, "udp6@", 5) == 0) {
 		str2 += 5;
 		ss.ss_family = AF_INET6;
@@ -1094,6 +1108,13 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 		ss.ss_family = AF_UNSPEC;
 		proto_type = PROTO_TYPE_STREAM;
 		ctrl_type = SOCK_STREAM;
+	}
+	else if (strncmp(str2, "mptcp@", 6) == 0) {
+		str2 += 6;
+		ss.ss_family = AF_UNSPEC;
+		proto_type = PROTO_TYPE_STREAM;
+		ctrl_type = SOCK_STREAM;
+		alt_proto = 1;
 	}
 	else if (strncmp(str2, "udp@", 4) == 0) {
 		str2 += 4;

--- a/src/tools.c
+++ b/src/tools.c
@@ -967,7 +967,7 @@ struct sockaddr_storage *str2ip2(const char *str, struct sockaddr_storage *sa, i
  */
 struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int *high, int *fd,
                                       struct protocol **proto, struct net_addr_type *sa_type,
-                                      char **err, const char *pfx, char **fqdn, unsigned int opts)
+                                      char **err, const char *pfx, char **fqdn, int *alt, unsigned int opts)
 {
 	static THREAD_LOCAL struct sockaddr_storage ss;
 	struct sockaddr_storage *ret = NULL;
@@ -979,6 +979,7 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 	int new_fd = -1;
 	enum proto_type proto_type = 0; // to shut gcc warning
 	int ctrl_type = 0; // to shut gcc warning
+	int alt_proto = 0;
 
 	portl = porth = porta = 0;
 	if (fqdn)
@@ -1002,6 +1003,7 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 	    ((opts & (PA_O_STREAM|PA_O_DGRAM)) == (PA_O_DGRAM|PA_O_STREAM) && (opts & PA_O_DEFAULT_DGRAM))) {
 		proto_type = PROTO_TYPE_DGRAM;
 		ctrl_type = SOCK_DGRAM;
+		alt_proto = 1;
 	} else {
 		proto_type = PROTO_TYPE_STREAM;
 		ctrl_type = SOCK_STREAM;
@@ -1016,6 +1018,7 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 		str2 += 6;
 		proto_type = PROTO_TYPE_DGRAM;
 		ctrl_type = SOCK_DGRAM;
+		alt_proto = 1;
 	}
 	else if (strncmp(str2, "quic+", 5) == 0) {
 		str2 += 5;
@@ -1034,6 +1037,7 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 		ss.ss_family = AF_UNIX;
 		proto_type = PROTO_TYPE_DGRAM;
 		ctrl_type = SOCK_DGRAM;
+		alt_proto = 1;
 	}
 	else if (strncmp(str2, "uxst@", 5) == 0) {
 		str2 += 5;
@@ -1070,6 +1074,7 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 		ss.ss_family = AF_INET;
 		proto_type = PROTO_TYPE_DGRAM;
 		ctrl_type = SOCK_DGRAM;
+		alt_proto = 1;
 	}
 	else if (strncmp(str2, "tcp6@", 5) == 0) {
 		str2 += 5;
@@ -1082,6 +1087,7 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 		ss.ss_family = AF_INET6;
 		proto_type = PROTO_TYPE_DGRAM;
 		ctrl_type = SOCK_DGRAM;
+		alt_proto = 1;
 	}
 	else if (strncmp(str2, "tcp@", 4) == 0) {
 		str2 += 4;
@@ -1094,6 +1100,7 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 		ss.ss_family = AF_UNSPEC;
 		proto_type = PROTO_TYPE_DGRAM;
 		ctrl_type = SOCK_DGRAM;
+		alt_proto = 1;
 	}
 	else if (strncmp(str2, "quic4@", 6) == 0) {
 		str2 += 6;
@@ -1367,7 +1374,7 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 		 */
 		new_proto = protocol_lookup(ss.ss_family,
 					    proto_type,
-					    ctrl_type == SOCK_DGRAM);
+					    alt_proto);
 
 		if (!new_proto && (!fqdn || !*fqdn) && (ss.ss_family != AF_CUST_EXISTING_FD)) {
 			memprintf(err, "unsupported %s protocol for %s family %d address '%s'%s",
@@ -1408,6 +1415,8 @@ struct sockaddr_storage *str2sa_range(const char *str, int *port, int *low, int 
 		sa_type->proto_type = proto_type;
 		sa_type->xprt_type = (ctrl_type == SOCK_DGRAM) ? PROTO_TYPE_DGRAM : PROTO_TYPE_STREAM;
 	}
+	if (alt)
+		*alt = alt_proto;
 	free(back);
 	return ret;
 }
@@ -6310,7 +6319,7 @@ const char *hash_ipanon(uint32_t scramble, char *ipstring, int hasport)
 			sa = &ss;
 		}
 		else {
-			sa = str2sa_range(ipstring, NULL, NULL, NULL, NULL, NULL, NULL, &errmsg, NULL, NULL,
+			sa = str2sa_range(ipstring, NULL, NULL, NULL, NULL, NULL, NULL, &errmsg, NULL, NULL, NULL,
 					  PA_O_PORT_OK | PA_O_STREAM | PA_O_DGRAM | PA_O_XPRT | PA_O_CONNECT |
 					  PA_O_PORT_RANGE | PA_O_PORT_OFS | PA_O_RESOLVE);
 			if (sa == NULL) {


### PR DESCRIPTION
Multipath TCP (MPTCP), standardized in RFC8684 [1], is a TCP extension that enables a TCP connection to use different paths.

Multipath TCP has been used for several use cases. On smartphones, MPTCP enables seamless handovers between cellular and Wi-Fi networks while preserving established connections. This use-case is what pushed Apple to use MPTCP since 2013 in multiple applications [2]. On dual-stack hosts, Multipath TCP enables the TCP connection to automatically use the best performing path, either IPv4 or IPv6. If one path fails, MPTCP automatically uses the other path.

To benefit from MPTCP, both the client and the server have to support it. Multipath TCP is a backward-compatible TCP extension that is enabled by default on recent Linux distributions (Debian, Ubuntu, Redhat, ...). Multipath TCP is included in the Linux kernel since version 5.6 [3]. To use it on Linux, an application must explicitly enable it when creating the socket. No need to change anything else in the application.

This attached patch adds MPTCP per address support, to be used with:

    mptcp{,4,6}@<address>[:port1[-port2]]

MPTCP v4 and v6 protocols have been added: they are mainly a copy of the TCP ones, with small differences: names, proto, and receivers lists.

These protocols are stored in `__protocol_by_family`, as an alternative to TCP, similar to what has been done with QUIC. By doing that, the size of `__protocol_by_family` has not been increased, and it behaves like TCP.

Link: https://www.rfc-editor.org/rfc/rfc8684.html [1]
Link: https://www.tessares.net/apples-mptcp-story-so-far/ [2]
Link: https://www.mptcp.dev [3]